### PR TITLE
added syntax highlighting for a few svelte items in all dark variations

### DIFF
--- a/themes/vxcode-dark-color-theme.json
+++ b/themes/vxcode-dark-color-theme.json
@@ -736,6 +736,33 @@
       "settings": {
         "foreground": "#C8C8C8"
       }
+    },
+    {
+      "scope": "support.class.component.svelte",
+      "settings": {
+        "foreground": "#DABAFF"
+      }
+    },
+    {
+      "scope": ["meta.embedded.block.svelte", "variable.other.readwrite"],
+      "settings": {
+        "foreground": "#ABF2E4"
+      }
+    },
+    {
+      "scope": ["meta.embedded.block.svelte", "variable.other.readwrite.alias"],
+      "settings": {
+        "foreground": "#DABAFF"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.variable.svelte",
+        "meta.scope.tag.svelte:head.svelte"
+      ],
+      "settings": {
+        "fontStyle": "bold"
+      }
     }
   ],
   "semanticHighlighting": true

--- a/themes/vxcode-darker-color-theme.json
+++ b/themes/vxcode-darker-color-theme.json
@@ -736,6 +736,33 @@
       "settings": {
         "foreground": "#C8C8C8"
       }
+    },
+    {
+      "scope": "support.class.component.svelte",
+      "settings": {
+        "foreground": "#DABAFF"
+      }
+    },
+    {
+      "scope": ["meta.embedded.block.svelte", "variable.other.readwrite"],
+      "settings": {
+        "foreground": "#ABF2E4"
+      }
+    },
+    {
+      "scope": ["meta.embedded.block.svelte", "variable.other.readwrite.alias"],
+      "settings": {
+        "foreground": "#DABAFF"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.variable.svelte",
+        "meta.scope.tag.svelte:head.svelte"
+      ],
+      "settings": {
+        "fontStyle": "bold"
+      }
     }
   ],
   "semanticHighlighting": true

--- a/themes/vxcode-oled-color-theme.json
+++ b/themes/vxcode-oled-color-theme.json
@@ -736,6 +736,33 @@
       "settings": {
         "foreground": "#C8C8C8"
       }
+    },
+    {
+      "scope": "support.class.component.svelte",
+      "settings": {
+        "foreground": "#DABAFF"
+      }
+    },
+    {
+      "scope": ["meta.embedded.block.svelte", "variable.other.readwrite"],
+      "settings": {
+        "foreground": "#ABF2E4"
+      }
+    },
+    {
+      "scope": ["meta.embedded.block.svelte", "variable.other.readwrite.alias"],
+      "settings": {
+        "foreground": "#DABAFF"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.variable.svelte",
+        "meta.scope.tag.svelte:head.svelte"
+      ],
+      "settings": {
+        "fontStyle": "bold"
+      }
     }
   ],
   "semanticHighlighting": true


### PR DESCRIPTION
Love the theme! Wanted it to show svelte components and a few other svelte things to have their own styles, based on the theme's definition for react.